### PR TITLE
Update conditional check

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,4 @@
 - output verbosity
 - boto3 migration: https://boto3.readthedocs.io/en/latest/guide/migration.html https://github.com/boto/boto3
 - Ugh, figure out why tar keeps generating different shas for the same contents
+- Documentation

--- a/bin/openvpn-cert-generator
+++ b/bin/openvpn-cert-generator
@@ -12,7 +12,7 @@ env = SettingsDict()
 
 sanity_check()
 
-if (env['S3_REGION'] or env['S3_CERT_ROOT_PATH']):
+if (env['S3_REGION'] and env['S3_CERT_ROOT_PATH']):
     conn = core.s3_wrapper.init_s3_connection(env['S3_REGION'])
     core.s3_wrapper.pull_latest_certs_from_root_path(conn, env)
 
@@ -22,5 +22,5 @@ core.client.revoke_client('dummy', env)
 [core.client.build_client(client, env) for client in env['ACTIVE_CLIENTS'].strip().split(",")]
 [core.client.revoke_client(client, env) for client in env['REVOKED_CLIENTS'].strip().split(",")]
 
-if (env['S3_REGION'] or env['S3_CERT_ROOT_PATH']):
+if (env['S3_REGION'] and env['S3_CERT_ROOT_PATH']):
     core.s3_wrapper.push_certs_to_root_path(conn, env)


### PR DESCRIPTION
Everything looked good in the openvpn-cert module.  Just one of the conditions should be an 'and' not an 'or'.  

For the MD5 size changing, that is due to tar including the timestamp.  If we regenerate the files, even in the contents of the files are identical, the tar size will change due to the timestamp.  If we want to keep track of only changed files, then we'd need to compare the files, before tar'ing them up.
