### PR TITLE
Add virtualenv to Vagrantfile in order to remove sudo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,7 @@ Vagrant.configure(2) do |config|
   # config.vm.network "forwarded_port", guest: 80, host: 8080
 
   config.vm.network :forwarded_port, guest: 22, host: 2202, id: 'ssh'
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -71,9 +72,10 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
    config.vm.provision "shell", inline: <<-SHELL
-     #sudo apt-get update
+     sudo apt-get update
      sudo apt-get install -y python-pip easy-rsa
-     cd /vagrant && sudo pip install -e .
+     pip install virtualenv && virtualenv . && source bin/activate
+     cd /vagrant && pip install -e .
    SHELL
 end
 


### PR DESCRIPTION
Greetings folks!
I offer my suggestions here in this pull request.
- Adding the `config.ssh.shell` option allows vagrant to [start bash as a non-login shell](https://github.com/mitchellh/vagrant/issues/1673) which prevents a `stdin: is not a tty` error from coming up.
- Removing the commented out `sudo apt-get update` as the vagrant provisioner only runs when the virtual machine is created unless the option `--provision` is passed the next time you run vagrant.
- Adding a virtualenv prevents the potential of corrupting system libraries.  This layer of separation can be useful even in a sandboxed operating system whether in a [virtual machine or a container](https://youtu.be/5BqAeN-F9Qs?t=20m45s).
- Speaking of containers, you can achieve a similar sandbox with this command:

```
docker run -i --rm -v $(pwd):/opt -w='/opt' python:2 /bin/bash -c "virtualenv venv && source venv/bin/activate && pip install -e ."
```

Please let me know what you think about these suggestions.
